### PR TITLE
Bytt ut vitest-dom med @react-testing-library/jest-dom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
       testing:
         patterns:
           - 'vitest'
-          - 'vitest-dom'
+          - '@testing-library/jest-dom'
           - 'vitest-axe'
           - '@vitejs/plugin-react'
           - 'open'

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.1.0",
         "vitest": "^0.34.6",
-        "vitest-dom": "^0.1.1"
+        "@testing-library/jest-dom": "6.4.2"
     },
     "packageManager": "yarn@4.0.1",
     "msw": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
         "esModuleInterop": true,
+        "types": ["vitest", "@testing-library/jest-dom"],
         "module": "esnext",
         "moduleResolution": "node",
         "resolveJsonModule": true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,13 +1,9 @@
-import 'vitest-dom/extend-expect'
-
-import * as matchers from 'vitest-dom/matchers'
-import { vi, expect, afterEach, beforeAll, afterAll } from 'vitest'
+import '@testing-library/jest-dom/vitest';
+import { vi, afterEach, beforeAll, afterAll } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import Modal from 'nav-frontend-modal'
 
 import { server } from './src/mocks/server'
-
-expect.extend(matchers)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dirtyGlobal = global as any


### PR DESCRIPTION
Hei ✋

Jeg så at dere brukte en utdatert dependency for test assertions som ikke blir så veldig maintained lenger, da @react-testing-library/jest-dom nå støtter vitest.

Tenkte jeg kunne legge inn en PR for dere da jeg allerede gjør dette for et annet prosjekt 😄 

NB: Får ikke testet det helt siden jeg ikke har npm credentials 😃 også derfor jeg ikke har oppdatert lock-filen